### PR TITLE
fix(ci): Handle multi-line grep output in pre-merge gate

### DIFF
--- a/.github/workflows/pre-merge-gate.yml
+++ b/.github/workflows/pre-merge-gate.yml
@@ -76,9 +76,12 @@ jobs:
         run: |
           TASKS_FILE="${{ steps.find.outputs.spec_dir }}/tasks.md"
 
-          # Count tasks
-          TOTAL=$(grep -cE "^\s*-\s*\[.\]\s*T[0-9]+" "$TASKS_FILE" 2>/dev/null || echo 0)
-          COMPLETE=$(grep -cE "^\s*-\s*\[X\]\s*T[0-9]+" "$TASKS_FILE" 2>/dev/null || echo 0)
+          # Count tasks (head -1 ensures single value if grep returns multiple lines)
+          TOTAL=$(grep -cE "^\s*-\s*\[.\]\s*T[0-9]+" "$TASKS_FILE" 2>/dev/null | head -1 || echo 0)
+          COMPLETE=$(grep -cE "^\s*-\s*\[X\]\s*T[0-9]+" "$TASKS_FILE" 2>/dev/null | head -1 || echo 0)
+          # Ensure numeric values
+          TOTAL=${TOTAL:-0}
+          COMPLETE=${COMPLETE:-0}
           INCOMPLETE=$((TOTAL - COMPLETE))
 
           echo "total=$TOTAL" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Fix bash arithmetic error when grep -c returns multiple lines
- Add head -1 to ensure single value
- Add default value fallback for empty results

## Test plan
- [x] Workflow syntax validated
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)